### PR TITLE
Remove reference to /lib/jquery.js in default.html

### DIFF
--- a/sdk/JavaScript/ZumoE2ETestAppJs/ZumoE2ETestAppJs/default.html
+++ b/sdk/JavaScript/ZumoE2ETestAppJs/ZumoE2ETestAppJs/default.html
@@ -10,7 +10,6 @@
     <script src="//Microsoft.WinJS.1.0/js/ui.js"></script>
 
     <!-- ZumoE2ETestAppJs references -->
-    <script type="text/javascript" src="/lib/jquery.js"></script>
     <link href="css/default.css" rel="stylesheet" />
     <script src="/js/default.js"></script>
     <script src="js/wl.js"></script>


### PR DESCRIPTION
This reference to lib/jquery.js breaks tests and causes a  bunch of other files not to be found. 
