### PR TITLE
Remove MobileAppUser from test app

### DIFF
--- a/Runtime/DotNetE2EServerApp/App_Start/Startup.MobileApp.cs
+++ b/Runtime/DotNetE2EServerApp/App_Start/Startup.MobileApp.cs
@@ -10,6 +10,7 @@ using System.Web.Http;
 using System.Web.Http.Cors;
 using AutoMapper;
 using Microsoft.Azure.Mobile.Server;
+using Microsoft.Azure.Mobile.Server.Authentication;
 using Microsoft.Azure.Mobile.Server.Config;
 using Microsoft.Owin.Extensions;
 using Owin;
@@ -70,7 +71,7 @@ namespace ZumoE2EServerApp
 
             Database.SetInitializer(new DbInitializer());
 
-            app.UseMobileAppAuthentication(config);
+            app.UseMobileAppAuthentication(config, AppServiceAuthenticationMode.LocalOnly);
             app.UseWebApi(config);
             app.UseStageMarker(PipelineStage.MapHandler);
         }

--- a/Runtime/DotNetE2EServerApp/Controllers/Api/PermissionsApiControllers.cs
+++ b/Runtime/DotNetE2EServerApp/Controllers/Api/PermissionsApiControllers.cs
@@ -16,27 +16,27 @@ namespace ZumoE2EServerApp.Controllers
     {
         public Task<HttpResponseMessage> Get()
         {
-            return CustomSharedApi.handleRequest(this.Request, (MobileAppUser)this.User);
+            return CustomSharedApi.handleRequest(this.Request, this.User);
         }
 
         public Task<HttpResponseMessage> Post()
         {
-            return CustomSharedApi.handleRequest(this.Request, (MobileAppUser)this.User);
+            return CustomSharedApi.handleRequest(this.Request, this.User);
         }
 
         public Task<HttpResponseMessage> Put()
         {
-            return CustomSharedApi.handleRequest(this.Request, (MobileAppUser)this.User);
+            return CustomSharedApi.handleRequest(this.Request, this.User);
         }
 
         public Task<HttpResponseMessage> Delete()
         {
-            return CustomSharedApi.handleRequest(this.Request, (MobileAppUser)this.User);
+            return CustomSharedApi.handleRequest(this.Request, this.User);
         }
 
         public Task<HttpResponseMessage> Patch()
         {
-            return CustomSharedApi.handleRequest(this.Request, (MobileAppUser)this.User);
+            return CustomSharedApi.handleRequest(this.Request, this.User);
         }
     }
 

--- a/Runtime/DotNetE2EServerApp/Controllers/Api/PushApiController.cs
+++ b/Runtime/DotNetE2EServerApp/Controllers/Api/PushApiController.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Security.Claims;
+using System.Security.Principal;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web.Http;
@@ -231,9 +233,9 @@ namespace ZumoE2EServerApp.Controllers
 
         private async Task<bool> VerifyTags(string channelUri, string installationId, NotificationHubClient nhClient)
         {
-            MobileAppUser user = (MobileAppUser)this.User;
+            IPrincipal user = this.User;
             int expectedTagsCount = 1;
-            if (user.Id != null)
+            if (user.Identity != null)
             {
                 expectedTagsCount = 2;
             }
@@ -253,7 +255,12 @@ namespace ZumoE2EServerApp.Controllers
                     {
                         return false;
                     }
-                    if (expectedTagsCount > 1 && !registration.Tags.Contains("_UserId:" + user.Id))
+
+                    ClaimsIdentity identity = user.Identity as ClaimsIdentity;
+                    Claim userIdClaim = identity.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier);
+                    string userId = (userIdClaim != null) ? userIdClaim.Value : string.Empty;
+
+                    if (expectedTagsCount > 1 && !registration.Tags.Contains("_UserId:" + userId))
                     {
                         return false;
                     }

--- a/Runtime/DotNetE2EServerApp/Utils/CustomSharedApi.cs
+++ b/Runtime/DotNetE2EServerApp/Utils/CustomSharedApi.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Security.Principal;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Azure.Mobile.Server.Authentication;
@@ -19,7 +20,7 @@ namespace ZumoE2EServerApp.Utils
     {
         internal static async Task<HttpResponseMessage> handleRequest(
             HttpRequestMessage request,
-            MobileAppUser user)
+            IPrincipal user)
         {
             var query = request.GetQueryNameValuePairs();
 
@@ -107,13 +108,13 @@ namespace ZumoE2EServerApp.Utils
 
     class NodeUser
     {
-        public NodeUser(MobileAppUser user)
+        public NodeUser(IPrincipal user)
         {
-            this.Id = user.Id;
+            this.Id = user.Identity.Name;
             if (user.Identity.IsAuthenticated)
             {
                 this.Level = "authenticated";
-                this.Id = user.Id;
+                this.Id = user.Identity.Name;
             }
             else
             {


### PR DESCRIPTION
Remove MobileAppUser from test app, change how User.Id is gotten to check the NameIdentifier claim.
This will enable the E2E test app to work with the new ServerSDK.

Still need to change project refs to point to the new server sdk package once it is available.